### PR TITLE
:mortar_board: Readme --- Add bash and testing details

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ venv\Scripts\activate.bat
 pip install .
 ```
 
+## Bash
+
+```sh
+python3.11 -m venv --clear --prompt cs263 venv
+. venv/bin/activate
+pip install .
+```
 
 # Build
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Your typical computer architecture course starting with transistors and ending w
 The course can be found [here](http://modsurski.com/csci263).
 
 
+
 # Setup
 
 ## Windows
@@ -19,6 +20,7 @@ venv\Scripts\activate.bat
 pip install .
 ```
 
+
 ## Bash
 
 ```sh
@@ -26,6 +28,18 @@ python3.11 -m venv --clear --prompt cs263 venv
 . venv/bin/activate
 pip install .
 ```
+
+
+
+# Unit Tests
+
+Assuming Java and [Digital](https://github.com/hneemann/Digital) are available.
+
+```sh
+java -cp Digital.jar CLI test ./path_to_schematics/schematic_with_tests.dig
+```
+
+
 
 # Build
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Your typical computer architecture course starting with transistors and ending w
 
 The course can be found [here](http://modsurski.com/csci263).
 
+This course makes use of [Digital](https://github.com/hneemann/Digital) to create circuits. 
+
 
 
 # Setup


### PR DESCRIPTION
### What

1. Mention digital in the opening part of the README
2. Include the bash code for activating the virtual environment and running setup
3. Show example of running tests in the schematics 


### Why

1. Because they would need it
2. In case some nerds are using bash 
3. So they don't have to read through the documentation of Digital 

