### PR TITLE
:mortar_board: Topic number bases --- Remove meaning section

### DIFF
--- a/site/topics/numbers/number-bases.rst
+++ b/site/topics/numbers/number-bases.rst
@@ -420,11 +420,6 @@ Converting Numbers Between Bases
 
 
 
-*Meaning*
-=========
-
-
-
 For Next Time
 =============
 


### PR DESCRIPTION
### What

Remove the "meaning" section

### Why

There were a few dimensions of _meaning_ that I was going to get at. One was the fact that the written number is just an encoding, which I feel is already hit throughout the topic already. This is fine at this stage. 

But, as _meaning_ is explored more, like how the binary is just a pattern that may matter for some architecture, or how `01100001` is 97 or maybe `a`, or how a word is decoded however we want.... it defo starts to get way ahead of where it needs to. 

Instead, these ideas will be discussed later in the course where it makes more sense. 

@twentylemon brought this up in #6 
