### PR TITLE
:bug: Outline --- Fix course grade breakdown :microscope: 

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -111,8 +111,8 @@ Student Evaluation (Tentative Dates)
     * - Deliverable
       - Percentage
       - Due Date
-    * - Assignments
-      - 20%
+    * - Assignment 1
+      - 5%
       - End of January-ish
     * - Assignment 2
       - 5%


### PR DESCRIPTION
### What

Fix the assignments breakdown in the course grade breakdown. 

### Why

It was wrong. I assume it happened because I started making `Assignments` one entry with a total of `20%`, but finished off with 3 other assignments? 

### How

Have an entry in the table for each assignment. 

`Assignments    20%` -> `Assignment 1    5%`

### Testing
YOLO
