### PR TITLE
:bug: Topic number bases --- Fix "digit" "name" (two hundred and fifty fives -> two hundred and fifty sixes :microscope: 

### DIFF
--- a/site/topics/numbers/number-bases.rst
+++ b/site/topics/numbers/number-bases.rst
@@ -488,7 +488,7 @@ Hexadecimal (Base 16)
           - :math:`16^{1}`
           - :math:`16`
         * - Third Digit
-          - Two Hundred and Fifty Fives
+          - Two Hundred and Fifty Sixes
           - :math:`16^{2}`
           - :math:`255`
         * - Fourth Digit


### PR DESCRIPTION
### What

Fix 3rd digit name for base 16


### How

"Two Hundred and Fifty Fives" -> "Two Hundred and Fifty Sixes"

### Testing

Nah
