### PR TITLE
🎓 Topic conditions --- Create pages for conditional topics 

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -85,6 +85,8 @@ Office Hours
     topics/control-logic/instructions-microcodes
     topics/control-logic/control-logic
     topics/programming/programming-machine-code
+    topics/conditions/conditions
+    topics/conditions/conditional-jump
 
 
 

--- a/site/topics/conditions/conditional-jump.rst
+++ b/site/topics/conditions/conditional-jump.rst
@@ -1,0 +1,28 @@
+=============================
+Conditional Jump Instructions
+=============================
+
+* The various status flag values can now be determined and stored in the flags register
+* However, how should the conditional jumps be handled by the control logic?
+* Further, the existing control logic needs to be updated to now handle the new flag register control signal
+
+    * When should the system's status signal values be stored stored in the flags register?
+
+
+
+Conditional Jump Control Logic
+==============================
+
+
+
+Including the Flag Register in the System
+=========================================
+
+
+
+For Next Time
+=============
+
+* Something?
+
+

--- a/site/topics/conditions/conditional-jump.rst
+++ b/site/topics/conditions/conditional-jump.rst
@@ -20,6 +20,11 @@ Including the Flag Register in the System
 
 
 
+Programming with Conditional Jumps
+==================================
+
+
+
 For Next Time
 =============
 

--- a/site/topics/conditions/conditions.rst
+++ b/site/topics/conditions/conditions.rst
@@ -1,0 +1,37 @@
+==========
+Conditions
+==========
+
+* Although the system is programmable, it currently has a significant limitation
+* To highlight this limitation, consider the problem the following problem
+
+    * Given some number, output ``1`` if it is less than ``10``, otherwise, output ``0``
+
+
+* It turns out that it's not possible as there is no way to check a condition
+
+    * Think ``If`` statements
+
+
+
+Conditional Jump Command
+========================
+
+
+Status Flags
+------------
+
+
+
+Flags Register
+==============
+
+
+
+
+For Next Time
+=============
+
+* Something?
+
+


### PR DESCRIPTION
### What

Create topic pages and base layout for the topics:
- Conditionals
- Conditional Jump Instructions

### How

Originally I was making it 1 topic, but it felt like it makes more sense as two, so that's why it's two pages 

### Testing

👍 

### Additional Notes

Sections may change a little, but this gives a starting point. 

After this topic, the assembler will be covered. This means the assembler as it is now will need to have 3 new instructions added (jump zero, jump carry, and jump significant/sign). 

Originally I thought I would do an assembler v1 that excludes the jump commands followed by a v2 that includes them, but I think it has a better flow to the course content if the assembler comes after and includes all instructions. 

As of now, I think the assembler may be the last topic of the course? Who knows. 

Based on the pace of the course, I fear I will not have enough content, so if I need more after the assembler I'm currently thinking I will update the system to be 16 bits, BUT for the fun of it I will do it with something like a shift register as the instruction register. 

In other words, each instruction is stored in two 8 bit RAM locations (big endian vs little endian style) so fetch needs to get both bytes into the instruction register. 

With 16 bits, there is obviously A LOT more flexibility:
- More memory addresses
- Bigger numbers (65536 unique values baby!)
- More instructions
- More operands in instructions for better generalizability 

(ideas vomitting done) 

