### PR TITLE
:broom: Topic instructions --- Remind them about PC in Jump :microscope: 

### DIFF
--- a/site/topics/control-logic/instructions-microcodes.rst
+++ b/site/topics/control-logic/instructions-microcodes.rst
@@ -594,7 +594,7 @@ The 13 Instructions
         * Output the operand (address to jump to) from the instruction register and put it into the program counter
 
     * Remember, the program counter stores the address of the *next* instruction to be run
-    * This way, the subsequent fetch will retrieve this value from the program counter
+    * This way, the fetch following the jump instruction will retrieve this new value from the program counter
 
 
 * ``1010``, ``1011``, and ``1100`` --- ``NOOP``

--- a/site/topics/control-logic/instructions-microcodes.rst
+++ b/site/topics/control-logic/instructions-microcodes.rst
@@ -593,6 +593,9 @@ The 13 Instructions
 
         * Output the operand (address to jump to) from the instruction register and put it into the program counter
 
+    * Remember, the program counter stores the address of the *next* instruction to be run
+    * This way, the subsequent fetch will retrieve this value from the program counter
+
 
 * ``1010``, ``1011``, and ``1100`` --- ``NOOP``
 


### PR DESCRIPTION
### What

When talking about the jump instruction, emphasize that the value stored in the program counter is the address of the _next_ instruction to be run. 

### Why

It makes it clearer why we want jump to put data into the program counter. 

### Testing

Nah

