### PR TITLE
🐛 🧑‍💻 Control Logic Script --- Fix comment 🔬 

### DIFF
--- a/site/topics/control-logic/create_control_logic_patterns_for_look_up_table.py
+++ b/site/topics/control-logic/create_control_logic_patterns_for_look_up_table.py
@@ -51,8 +51,8 @@ PCE = 0b0_00000000_00000010
 PCI = 0b0_00000000_00000001
 
 """
-Mirocodes for the 16 possible instructions. Each microcode could be up to 8 instructions long, but currently the max is 
-5, thus, there is some "wasted" space in the lookup table. Not all 16 operations are implemented here. 
+Mirocodes for the 16 possible instructions. Each microcode could be up to 4 instructions long. Not all 16 operations are 
+implemented here; three additional NOOPs are included. 
 """
 INSTRUCTIONS = [
   [PCO|ADR,   RMO|IRI|PCE, 0,           0           ],  # 0b0000 --- 0x0 --- NOOP --- No Operation


### PR DESCRIPTION
### What

Fix the comment about the instructions being up to 8 microcodes long. 

### Why

It's a lie. This was an out dated comment from an older version. 
