### PR TITLE
:bug: Topic combinational Logic --- Fix NAND functional completeness

### DIFF
--- a/site/topics/logic/functional_completeness.dig
+++ b/site/topics/logic/functional_completeness.dig
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <circuit>
-  <version>1</version>
+  <version>2</version>
   <attributes/>
   <visualElements>
     <visualElement>
@@ -187,12 +187,12 @@
       <elementName>Rectangle</elementName>
       <elementAttributes>
         <entry>
-          <string>Label</string>
-          <string>AND with OR and NOT Gates</string>
-        </entry>
-        <entry>
           <string>RectHeight</string>
           <int>14</int>
+        </entry>
+        <entry>
+          <string>Label</string>
+          <string>AND with OR and NOT Gates</string>
         </entry>
         <entry>
           <string>RectWidth</string>
@@ -626,36 +626,6 @@
       <pos x="1040" y="620"/>
     </visualElement>
     <visualElement>
-      <elementName>NOr</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-      </elementAttributes>
-      <pos x="1860" y="700"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NOr</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-      </elementAttributes>
-      <pos x="1860" y="780"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NOr</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-      </elementAttributes>
-      <pos x="2040" y="740"/>
-    </visualElement>
-    <visualElement>
       <elementName>In</elementName>
       <elementAttributes>
         <entry>
@@ -722,6 +692,36 @@
         </entry>
       </elementAttributes>
       <pos x="1740" y="620"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NAnd</elementName>
+      <elementAttributes>
+        <entry>
+          <string>wideShape</string>
+          <boolean>true</boolean>
+        </entry>
+      </elementAttributes>
+      <pos x="1860" y="780"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NAnd</elementName>
+      <elementAttributes>
+        <entry>
+          <string>wideShape</string>
+          <boolean>true</boolean>
+        </entry>
+      </elementAttributes>
+      <pos x="1860" y="700"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NAnd</elementName>
+      <elementAttributes>
+        <entry>
+          <string>wideShape</string>
+          <boolean>true</boolean>
+        </entry>
+      </elementAttributes>
+      <pos x="2040" y="740"/>
     </visualElement>
   </visualElements>
   <wires>

--- a/site/topics/logic/functional_completeness.dig
+++ b/site/topics/logic/functional_completeness.dig
@@ -683,10 +683,10 @@
         <entry>
           <string>Testdata</string>
           <testData>
-            <dataString>in_k	in_l	out_g
+            <dataString>in_m	in_n	out_h
 0	0	0
-0	1	0
-1	0	0
+0	1	1
+1	0	1
 1	1	1</dataString>
           </testData>
         </entry>


### PR DESCRIPTION
### What

Change the NAND layout for OR to use NAND gates instead of NOR gates. 

### Why

It was originally a copy of the AND with NOR gates

### How
It was this, which was a lie
<img width="788" height="449" alt="image" src="https://github.com/user-attachments/assets/79017898-9f08-4d84-a7ff-69fbb1cc5748" />

And now it is this, which is correct 
<img width="603" height="309" alt="image" src="https://github.com/user-attachments/assets/4c3f52ee-ce23-4aeb-b6bb-41dbbe8fa7c6" />

### Testing

:+1: Had to update tests too. 
