### PR TITLE
🎓 Lab instructions --- Include bit patterns for ALU instrutions 🔬 

### DIFF
--- a/site/labs/decoding-instructions/decoding-instructions.rst
+++ b/site/labs/decoding-instructions/decoding-instructions.rst
@@ -37,14 +37,14 @@ ALU
 
     * The eight operations are as follows
 
-        * Return A unchanged
-        * 2s compliment negation
-        * ``NOT`` A
-        * ``Or``
-        * ``AND``
-        * ``XOR``
-        * Addition
-        * Subtraction
+        * ``000`` --- Return A unchanged
+        * ``001`` --- 2s compliment negation
+        * ``010`` --- ``NOT`` A
+        * ``011`` --- ``Or``
+        * ``100`` --- ``AND``
+        * ``101`` --- ``XOR``
+        * ``110`` --- Addition
+        * ``111`` --- Subtraction
 
 
     * The three 1 bit inputs specify the operator in the above order


### PR DESCRIPTION
### What

Add the corresponding bit patterns for the ALU

### Why

1. More explicitly clear
2. I did show the bit pattern for the comparator in the next question, so this makes it more consistent 
