### PR TITLE
🥼 Lab patterns, instructions, registers --- Fix 3 -> 2 sources 🔬 

### DIFF
--- a/site/labs/decoding-instructions/decoding-instructions-registers.rst
+++ b/site/labs/decoding-instructions/decoding-instructions-registers.rst
@@ -77,7 +77,7 @@ Currently there is no way to actually load data into the system.
     * Update the system such that one of these 4 modes allows for loading data directly to a register
 
         * The 3 destination register bits specify where the data is to be stored
-        * 8 bits of the 9 available for the operator and 3 source registers specify the 8 bit data
+        * 8 bits of the 9 available for the operator and 2 source registers specify the 8 bit data
 
 
     * For example, consider the below bit patterns and their meanings


### PR DESCRIPTION
### What

Change "3 source" to "2 source"

### Why

3 is a lie; there is no 3, there is only 2. 